### PR TITLE
fixed source assignment and added string interpolation support

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -9,6 +9,9 @@ Changelog
 - Added exception, if text-variable is used, but an item doesn't have a text-field.
   Concerns actions/mail.py [ida]
 
+- Fixed source address assignment. Now doesn't break the rule execution[cekk]
+
+- Enabled the use of string interpolator for string substitutions [cekk]
 
 1.3 (2012-02-15)
 -------------------


### PR DESCRIPTION
Hi, i've fixed a few things:
- added string interpolation support
- fixed a bug that breaks rule execution when an email source address was set in the rule
- Removed "To" address, because i think that all recipients should be hidden, and some times the address in site's properties doesn't want to receive this kind of mails.

I tried to run tests, but thy doesn't run for some problem with the mailhost and the particulart mimetype used for these mails.

I was also thinking to drop multipart emails and return to standard text mails used in other plone rules. What do you think about it? Otherwise we could add a flag in the rule that allows to choose wich format to use.
